### PR TITLE
Move cleanup to occur on "CONNECTED" event.

### DIFF
--- a/source/wpa3_ext_supp.c
+++ b/source/wpa3_ext_supp.c
@@ -1538,13 +1538,13 @@ void wpa3_auth_join_callback (cy_wcm_event_t event, cy_wcm_event_data_t *event_d
     {
         case CY_WCM_EVENT_CONNECTING:
             WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_CONNECTING\n"));
+            break;
+        case CY_WCM_EVENT_CONNECTED:
+            WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_CONNECTED\n"));
             if ( wksp != NULL )
             {
                 wpa3_sae_cleanup_workspace();
             }
-            break;
-        case CY_WCM_EVENT_CONNECTED:
-            WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_CONNECTED\n"));
             break;
         case CY_WCM_EVENT_CONNECT_FAILED:
             WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_CONNECT_FAILED\n"));
@@ -1560,7 +1560,7 @@ void wpa3_auth_join_callback (cy_wcm_event_t event, cy_wcm_event_data_t *event_d
             WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_DISCONNECTED\n"));
             break;
         case CY_WCM_EVENT_IP_CHANGED:
-            WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_CONNECTING\n"));
+            WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_IP_CHANGED\n"));
             break;
         case CY_WCM_EVENT_INITIATED_RETRY:
             WPA3_EXT_LOG_MSG(("\nWPA3-EXT-SUPP:CY_WCM_EVENT_INITIATED_RETRY\n"));


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Bug fix - clean up data structures and free memory once connected, not while still connecting.
This contribution is made available under the BSD-3 license, please see below.

Copyright 2024 Verily Life Sciences LLC

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.